### PR TITLE
Skeleton and mesh improvements

### DIFF
--- a/cgal_skeletonize_mesh/skeletonize_mesh.cpp
+++ b/cgal_skeletonize_mesh/skeletonize_mesh.cpp
@@ -110,7 +110,18 @@ int main(int argc, char* argv[])
   }
 
   Skeleton skeleton;
-  CGAL::extract_mean_curvature_flow_skeleton(mesh, skeleton);
+
+  // Create MCF skeletonization object with explicit parameters
+  typedef CGAL::Mean_curvature_flow_skeletonization<Polyhedron> MCF_Skel;
+  MCF_Skel mcs(mesh);
+
+  // Tweak parameters to try to keep the skeleton inside
+  mcs.set_is_medially_centered(true);              // redundant with defaults, but explicit
+  mcs.set_medially_centered_speed_tradeoff(0.3);   // > default .3 worked well
+  mcs.set_quality_speed_tradeoff(0.5);             // > default .5 worked well
+
+  mcs.contract_until_convergence();
+  mcs.convert_to_skeleton(skeleton);
   
   // Output all the edges of the skeleton.
   if (boost::num_vertices(skeleton) == 0)

--- a/cgal_skeletonize_mesh/skeletonize_mesh.cpp
+++ b/cgal_skeletonize_mesh/skeletonize_mesh.cpp
@@ -7,6 +7,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <cstring>
 
 
 
@@ -53,10 +54,151 @@ struct Display_polylines{
 
 void print_usage(const char* prog) {
   std::cerr
-    << "Usage: " << prog << " <input.ply> <output.skel> [loop_subdivision_iterations]\n"
+    << "Usage: " << prog << " <input.ply> <output.skel> [loop_subdivision_iterations] [--neuroglancer_format]\n"
     << "  <input.ply>                  : your triangulated mesh file\n"
     << "  <output.skel>                : where to write the skeleton\n"
-    << "  [loop_subdivision_iterations]: optional integer (default 0)\n";
+    << "  [loop_subdivision_iterations]: optional integer (default 0)\n"
+    << "  [--neuroglancer_format]      : flag to indicate input is in neuroglancer format\n";
+}
+
+// Function to read neuroglancer formatted mesh
+bool read_neuroglancer_mesh(const std::string& filename, Polyhedron& mesh) {
+  std::ifstream input(filename, std::ios::binary);
+  if (!input) {
+    std::cerr << "Error: cannot open file " << filename << std::endl;
+    std::cerr << "Note: Make sure the file exists and you have read permissions" << std::endl;
+    return false;
+  }
+
+  // Get file size for validation
+  input.seekg(0, std::ios::end);
+  std::streamsize file_size = input.tellg();
+  input.seekg(0, std::ios::beg);
+
+  if (file_size < 4) {
+    std::cerr << "Error: file too small (" << file_size << " bytes), must be at least 4 bytes" << std::endl;
+    return false;
+  }
+
+  // Check if this is a Draco-compressed file
+  char magic[5] = {0};
+  input.read(magic, 5);
+  input.seekg(0, std::ios::beg);
+
+  if (std::strncmp(magic, "DRACO", 5) == 0) {
+    std::cerr << "Error: file appears to be Draco-compressed (starts with 'DRACO')" << std::endl;
+    std::cerr << "This format is not supported. Please decompress the Draco file first." << std::endl;
+    std::cerr << "You can use DracoPy in Python to decode it, or convert to PLY format." << std::endl;
+    return false;
+  }
+
+  std::cerr << "Reading uncompressed neuroglancer mesh from " << filename << " (" << file_size << " bytes)" << std::endl;
+
+  // Read number of vertices (4 bytes, little-endian uint32)
+  uint32_t num_vertices;
+  input.read(reinterpret_cast<char*>(&num_vertices), sizeof(uint32_t));
+  if (!input) {
+    std::cerr << "Error: failed to read num_vertices" << std::endl;
+    return false;
+  }
+
+  // Sanity check: ensure num_vertices is reasonable given file size
+  size_t min_expected_size = 4 + (num_vertices * 3 * sizeof(float)); // header + vertices only
+  if (num_vertices > 1000000000 || min_expected_size > file_size * 10) {
+    std::cerr << "Error: num_vertices value seems unreasonable: " << num_vertices << std::endl;
+    std::cerr << "This may indicate the wrong file format or corrupted data" << std::endl;
+    return false;
+  }
+
+  std::cerr << "Number of vertices: " << num_vertices << std::endl;
+
+  // Read vertex positions (3 * num_vertices floats, little-endian)
+  std::vector<Point_3> vertices;
+  vertices.reserve(num_vertices);
+  for (uint32_t i = 0; i < num_vertices; ++i) {
+    float x, y, z;
+    input.read(reinterpret_cast<char*>(&x), sizeof(float));
+    input.read(reinterpret_cast<char*>(&y), sizeof(float));
+    input.read(reinterpret_cast<char*>(&z), sizeof(float));
+    if (!input) {
+      std::cerr << "Error: failed to read vertex " << i << std::endl;
+      return false;
+    }
+    vertices.push_back(Point_3(x, y, z));
+  }
+
+  // Calculate number of triangles from remaining bytes
+  std::streampos current_pos = input.tellg();
+  input.seekg(0, std::ios::end);
+  std::streampos end_pos = input.tellg();
+  size_t remaining_bytes = end_pos - current_pos;
+
+  if (remaining_bytes % 12 != 0) {
+    std::cerr << "Error: invalid number of remaining bytes for triangles: " << remaining_bytes << std::endl;
+    return false;
+  }
+
+  uint32_t num_triangles = remaining_bytes / 12;
+  input.seekg(current_pos);
+  std::cerr << "Number of triangles: " << num_triangles << std::endl;
+
+  // Read triangle indices (3 * num_triangles uint32s, little-endian)
+  std::vector<std::array<uint32_t, 3>> faces;
+  faces.reserve(num_triangles);
+  for (uint32_t i = 0; i < num_triangles; ++i) {
+    uint32_t a, b, c;
+    input.read(reinterpret_cast<char*>(&a), sizeof(uint32_t));
+    input.read(reinterpret_cast<char*>(&b), sizeof(uint32_t));
+    input.read(reinterpret_cast<char*>(&c), sizeof(uint32_t));
+    if (!input) {
+      std::cerr << "Error: failed to read triangle " << i << std::endl;
+      return false;
+    }
+    if (a >= num_vertices || b >= num_vertices || c >= num_vertices) {
+      std::cerr << "Error: invalid vertex index in triangle " << i << std::endl;
+      return false;
+    }
+    faces.push_back({a, b, c});
+  }
+
+  // Build polyhedron from vertices and faces
+  typedef CGAL::Polyhedron_incremental_builder_3<Polyhedron::HalfedgeDS> Builder;
+  struct Build_mesh : public CGAL::Modifier_base<Polyhedron::HalfedgeDS> {
+    const std::vector<Point_3>& vertices;
+    const std::vector<std::array<uint32_t, 3>>& faces;
+
+    Build_mesh(const std::vector<Point_3>& v, const std::vector<std::array<uint32_t, 3>>& f)
+      : vertices(v), faces(f) {}
+
+    void operator()(Polyhedron::HalfedgeDS& hds) {
+      Builder builder(hds, true);
+      builder.begin_surface(vertices.size(), faces.size());
+
+      // Add vertices
+      for (const auto& v : vertices) {
+        builder.add_vertex(v);
+      }
+
+      // Add faces
+      for (const auto& f : faces) {
+        builder.begin_facet();
+        builder.add_vertex_to_facet(f[0]);
+        builder.add_vertex_to_facet(f[1]);
+        builder.add_vertex_to_facet(f[2]);
+        builder.end_facet();
+      }
+
+      builder.end_surface();
+    }
+  };
+
+  Build_mesh builder(vertices, faces);
+  mesh.delegate(builder);
+
+  std::cerr << "Successfully built polyhedron with " << mesh.size_of_vertices()
+            << " vertices and " << mesh.size_of_facets() << " faces" << std::endl;
+
+  return true;
 }
 
 
@@ -64,15 +206,32 @@ void print_usage(const char* prog) {
 
 int main(int argc, char* argv[])
 {
-  if (argc < 3 || argc > 4) {
+  if (argc < 3 || argc > 5) {
     print_usage(argv[0]);
     return EXIT_FAILURE;
   }
+
+  // Check for --neuroglancer flag
+  bool use_neuroglancer = false;
+  for (int i = 3; i < argc; ++i) {
+    if (std::strcmp(argv[i], "--neuroglancer_format") == 0) {
+      use_neuroglancer = true;
+      break;
+    }
+  }
+
   std::string comments;
-  // create mesh as epick mesh
-  std::ifstream input(argv[1]);
   Polyhedron mesh;
-  bool read_ok = CGAL::IO::read_PLY(input, mesh);
+  bool read_ok;
+
+  // Load mesh based on format
+  if (use_neuroglancer) {
+    read_ok = read_neuroglancer_mesh(argv[1], mesh);
+  } else {
+    std::ifstream input(argv[1]);
+    read_ok = CGAL::IO::read_PLY(input, mesh);
+  }
+
   if(!read_ok){
    std::cout << "Error: reading the input file " << argv[1] << std::endl;
    return EXIT_FAILURE;
@@ -85,20 +244,25 @@ int main(int argc, char* argv[])
 
   // parse optional loop subdivision count
   int loop_subdivision_iterations = 0;
-  if (argc == 4) {
-    try {
-      loop_subdivision_iterations = std::stoi(argv[3]);
-      if (loop_subdivision_iterations < 0) throw std::out_of_range("negative");
-    }
-    catch (const std::invalid_argument&) {
-      std::cerr << "Error: loop_subdivision_iterations must be an integer\n";
-      print_usage(argv[0]);
-      return EXIT_FAILURE;
-    }
-    catch (const std::out_of_range&) {
-      std::cerr << "Error: loop_subdivision_iterations out of range\n";
-      print_usage(argv[0]);
-      return EXIT_FAILURE;
+  if (argc >= 4) {
+    for (int i = 3; i < argc; ++i) {
+      if (std::strcmp(argv[i], "--neuroglancer_format") != 0) {
+        try {
+          loop_subdivision_iterations = std::stoi(argv[i]);
+          if (loop_subdivision_iterations < 0) throw std::out_of_range("negative");
+          break;
+        }
+        catch (const std::invalid_argument&) {
+          std::cerr << "Error: loop_subdivision_iterations must be an integer\n";
+          print_usage(argv[0]);
+          return EXIT_FAILURE;
+        }
+        catch (const std::out_of_range&) {
+          std::cerr << "Error: loop_subdivision_iterations out of range\n";
+          print_usage(argv[0]);
+          return EXIT_FAILURE;
+        }
+      }
     }
   }
 
@@ -136,7 +300,7 @@ int main(int argc, char* argv[])
   // assign indices to vertices
   for(Skeleton_vertex v : CGAL::make_range(vertices(skeleton))){
     Point_3 skeleton_vertex = skeleton[v].point;
-    float average_radius, radius = 0;
+    float average_radius=0, radius = 0;
     if (skeleton[v].vertices.size() == 0)
       {// some vertices aren't associated with mesh vertices but we still want to calculate a radius for them
         float min_radius = std::numeric_limits<float>::max();


### PR DESCRIPTION
@stuarteberg
This pull request introduces significant improvements to mesh processing workflows, focusing on enhanced format support, more robust mesh simplification, and improved parameter handling. The main highlights are the addition of support for Neuroglancer mesh formats in the CGAL skeletonization tool, a switch to PyMeshLab for mesh simplification (replacing pyfqmr in most cases), and refactoring of simplification parameters for better control and consistency.

**Mesh Format Support**
* Added support for reading Neuroglancer mesh files in `cgal_skeletonize_mesh.cpp`, including error handling for Draco-compressed files and validation of mesh structure. This allows skeletonization of meshes in Neuroglancer's native format, broadening compatibility.
* Updated command-line usage and argument parsing in `cgal_skeletonize_mesh.cpp` to accept a `--neuroglancer_format` flag, enabling seamless switching between PLY and Neuroglancer formats. [[1]](diffhunk://#diff-4e05c76c2296ffc762d9d25029d738e7be3570f37467e4eefeb04e66c6803472L56-R234) [[2]](diffhunk://#diff-4e05c76c2296ffc762d9d25029d738e7be3570f37467e4eefeb04e66c6803472L88-R253) [[3]](diffhunk://#diff-4e05c76c2296ffc762d9d25029d738e7be3570f37467e4eefeb04e66c6803472R266-R267)

**Mesh Simplification Improvements**
* Introduced a new `pymeshlab_simplify` function in `fixed_edge_meshes.py` that uses PyMeshLab's quadric edge collapse decimation for mesh simplification, providing better robustness and preservation of mesh quality compared to pyfqmr. The main simplification workflow is now handled by the new `simplify_mesh` function. [[1]](diffhunk://#diff-a3db472d06d4908208adbcf7640e44f6159f17e5353960ce1d03d61f52d9030cR45-R92) [[2]](diffhunk://#diff-a3db472d06d4908208adbcf7640e44f6159f17e5353960ce1d03d61f52d9030cL564-R621) [[3]](diffhunk://#diff-a3db472d06d4908208adbcf7640e44f6159f17e5353960ce1d03d61f52d9030cR635-R662)
* Refactored mesh simplification calls throughout `meshes.py` to use `simplify_mesh` instead of the previous `simplify_block_preserve_edges`, ensuring the new, more robust simplification method is applied consistently. [[1]](diffhunk://#diff-8b7168fbb292aa1ad74815f4d1a122cb913899f817a5489e1414696ceb42fd05L41-R42) [[2]](diffhunk://#diff-8b7168fbb292aa1ad74815f4d1a122cb913899f817a5489e1414696ceb42fd05L260-R265) [[3]](diffhunk://#diff-8b7168fbb292aa1ad74815f4d1a122cb913899f817a5489e1414696ceb42fd05L323-R380)

**Parameter Consistency and Smoothing**
* Changed the default simplification aggressiveness parameter from `7` (int) to `0.3` (float) across the codebase, aligning with PyMeshLab's expectations and improving parameter clarity. [[1]](diffhunk://#diff-8b7168fbb292aa1ad74815f4d1a122cb913899f817a5489e1414696ceb42fd05L88-R85) [[2]](diffhunk://#diff-8b7168fbb292aa1ad74815f4d1a122cb913899f817a5489e1414696ceb42fd05L115-R112)
* Updated post-simplification smoothing to use PyMeshLab's Taubin smoothing directly, replacing previous methods and improving mesh quality after decimation.

**Skeletonization Enhancements**
* In `cgal_skeletonize_mesh.cpp`, replaced the default skeletonization call with explicit parameter settings for medial centering and tradeoffs, aiming for better skeleton quality and control.

These changes collectively make the mesh processing pipeline more robust, flexible, and easier to configure for different mesh formats and quality requirements.